### PR TITLE
File adapter unbuffered and change \d from UTC to current timezone

### DIFF
--- a/lib/Log/Any.pm6
+++ b/lib/Log/Any.pm6
@@ -131,7 +131,7 @@ Dies if severity is unknown.
 		}
 
 		# Capture the date as soon as possible
-		my $date-time = DateTime.new( now );
+		my $date-time = DateTime.now;
 
 		# Use the specified pipeline, or the default one
 		$pipeline //= '_default';

--- a/lib/Log/Any/Adapter/File.pm6
+++ b/lib/Log/Any/Adapter/File.pm6
@@ -6,7 +6,7 @@ class Log::Any::Adapter::File is Log::Any::Adapter {
 	has IO::Handle $!fh;
 
 	method BUILD( Str:D :$path ) {
-		$!fh = open $path, :a;
+		$!fh = open $path, :a, :0out-buffer;
 	}
 
 	method handle( $msg ) {


### PR DESCRIPTION
Hi,
I'm proposing two small changes, the first would make the File adapter unbuffered, so that log messages would appear as soon as the program outputs them.
The second is just a matter of my personal preference: I like to have the time shown as in the current time zone.